### PR TITLE
Fixed bug with api access using api_key without login/pass

### DIFF
--- a/testdroid/__init__.py
+++ b/testdroid/__init__.py
@@ -488,13 +488,14 @@ class Testdroid:
             print "Awaiting completion of test run with id %s. Will wait forever polling every %smins." % (test_run_id, Testdroid.polling_interval_mins)
             while True:
                 time.sleep(Testdroid.polling_interval_mins*60)
-                self.access_token = None    #WORKAROUND: access token thinks it's still valid,
-                                            # > token valid for another 633.357925177
-                                            #whilst this happens:
-                                            # > Couldn't establish the state of the test run with id: 72593732. Aborting
-                                            # > {u'error_description': u'Invalid access token: b3e62604-9d2a-49dc-88f5-89786ff5a6b6', u'error': u'invalid_token'}
+                if not self.api_key:
+                    self.access_token = None    #WORKAROUND: access token thinks it's still valid,
+                                                # > token valid for another 633.357925177
+                                                #whilst this happens:
+                                                # > Couldn't establish the state of the test run with id: 72593732. Aborting
+                                                # > {u'error_description': u'Invalid access token: b3e62604-9d2a-49dc-88f5-89786ff5a6b6', u'error': u'invalid_token'}
 
-                self.get_token()            #in case it expired
+                    self.get_token()            #in case it expired
                 testRunStatus = self.get_test_run(project_id, test_run_id)
                 if testRunStatus and testRunStatus.has_key('state'):
                     if testRunStatus['state'] == "FINISHED":


### PR DESCRIPTION
Hi! I spotted a small bug in the code - you can't execute `wait_test_run()` providing only api_key and not providing username/password. That happens because in `wait_test_run()` you are trying to refresh token while it might be not needed in case of using `api_key`.

Here you can see a fix for this that worked for me.