### PR TITLE
Don't update project separately while starting test run

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2.41.4
+ * Don't separately update project when calling start_test_run()
 2.41.3
  * Isolate Pillow import, with fallback if import fails
 2.41.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 import sys, os
 
 
-version = '2.41.3'
+version = '2.41.4'
 
 setup(name='testdroid',
       version=version,

--- a/testdroid/__init__.py
+++ b/testdroid/__init__.py
@@ -4,7 +4,7 @@ import os, sys, requests, json, logging, time, httplib, base64
 from optparse import OptionParser
 from datetime import datetime
 
-__version__ = '2.41.3'
+__version__ = '2.41.4'
 
 FORMAT = "%(message)s"
 logging.basicConfig(format=FORMAT)


### PR DESCRIPTION
Previously the api client would update the project before launching a test run using `start_test_run()`. This might cause race conditions when multiple users call the api client in close succession, and is unnecessary in any event since the `/users/%s/projects/%s/runs` call updates the project anyway.

Also, bumped version.

Users have requested this change.