### PR TITLE
Update me[name] and me[email] fields to match response from REST API

### DIFF
--- a/testdroid/__init__.py
+++ b/testdroid/__init__.py
@@ -398,7 +398,7 @@ class Testdroid:
     """
     def print_projects(self, limit=0):
         me = self.get_me()
-        print("Projects for %s %s <%s>:" % (me['firstName'], me['lastName'], me['mainUserEmail']))
+        print("Projects for %s %s <%s>:" % (me['firstName'], me['lastName'], me['email']))
 
         for project in self.get_projects(limit)['data']:
             print("%s %s \"%s\"" % (str(project['id']).ljust(10), project['type'].ljust(15), project['name']))

--- a/testdroid/__init__.py
+++ b/testdroid/__init__.py
@@ -398,7 +398,7 @@ class Testdroid:
     """
     def print_projects(self, limit=0):
         me = self.get_me()
-        print("Projects for %s <%s>:" % (me['name'], me['email']))
+        print("Projects for %s %s <%s>:" % (me['firstName'], me['lastName'], me['mainUserEmail']))
 
         for project in self.get_projects(limit)['data']:
             print("%s %s \"%s\"" % (str(project['id']).ljust(10), project['type'].ljust(15), project['name']))


### PR DESCRIPTION
I don't know when the Bitbar REST API changed, but testdroid appears to be referencing obsolete fields.
- `me[name]` -> `me[firstName] me[lastName]`
- `me[email]` -> `me[mainUserEmail]`